### PR TITLE
Add imageUrlHttp twig filter to get a URL with http and not https

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ You can use the filter like this:
 ```twig
 <img src="{{ imageSlug|imageUrl(width, height) }}" />
 ```
+
+And if you need HTTP (not HTTPs), use the filter like this:
+```twig
+<img src="{{ imageSlug|imageUrlHttp(width, height) }}" />
+```

--- a/src/Twig/UrlBuilderExtension.php
+++ b/src/Twig/UrlBuilderExtension.php
@@ -27,6 +27,7 @@ class UrlBuilderExtension extends AbstractExtension
     {
         return [
             new TwigFilter('imageUrl', [$this, 'imageUrl']),
+            new TwigFilter('imageUrlHttp', [$this, 'imageUrlHttp']),
         ];
     }
 
@@ -40,5 +41,17 @@ class UrlBuilderExtension extends AbstractExtension
         array $options = []
     ): string {
         return $this->builder->buildUrl($image, $width, $height, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function imageUrlHttp(
+        string $image,
+        int $width = 0,
+        int $height = 0,
+        array $options = []
+    ): string {
+        return $this->builder->withHttpPrefix()->buildUrl($image, $width, $height, $options);
     }
 }


### PR DESCRIPTION
### Nouveau comportement

On dispose de deux filtres twig : on conserve celui avec https (imageUrl) et on en ajoute un sans (imageUrlHttp).

### Comportement actuel

Le filtre twig impose d'utiliser des liens en https (ce qui n'est pas compatible avec wkhtmltopdf et nous oblige à ne pas passer par le filtre)