### PR TITLE
Safetynet for malformed imageSlug (i.e. from another twig filter or function)

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -43,7 +43,7 @@ class Builder
         int $height = 0,
         array $options = []
     ): string {
-        $image = $imageSlug;
+        $image = trim($imageSlug);
         if (0 === strpos($image, 'http://') || 0 === strpos($image, 'https://')) {
             $image = preg_replace('#^http(s)?://#', '//', $image);
         }


### PR DESCRIPTION
### Nouveau comportement

Je trim l'imageSlug avant d'appliquer des traitements.

### Comportement actuel

On prend l'imageSlug avec l'hypothèse qu'il est propre et bien formé, en particulier qu'il n'a ni espace ni tab autour de lui.

En réalité, on peut avoir d'autres fonctions twig qui ajoutent des espaces ou tab autour de la valeur et on se retrouve alors avec des URL genre `http://img.mapado.net/    2020/01/27/image_bidule.jpg` (ce qui s'est passé dans la vraie vie d'où ma PR).
