### PR TITLE
Server is now http2 + Allow resize based on height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.0
+
+Remove use of img/img1 as we are now multiplexing with http2
+Add option allowwebp to enable webp optimization even for not resized images
+Allow =0 width, with >= height to resize based on set height
+
 ## 2.1.1
 
 Fix malformed imageSlug parameter in buildUrl

--- a/Tests/Units/BuilderTest.php
+++ b/Tests/Units/BuilderTest.php
@@ -25,11 +25,11 @@ class BuilderTest extends TestCase
         $url = $this->manager->buildUrl($baseUrl);
         $this->assertSame($baseUrl, $url);
 
-        $baseUrl = '//img1.mapado.net/2014/1/1/my-image.png';
+        $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
         $url = $this->manager->buildUrl($baseUrl);
         $this->assertSame($baseUrl, $url);
 
-        $baseUrl = '//img2.mapado.net/2014/1/1/my-image.png';
+        $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
         $url = $this->manager->buildUrl($baseUrl);
         $this->assertSame($baseUrl, $url);
     }
@@ -39,11 +39,15 @@ class BuilderTest extends TestCase
     {
         $baseUrl = '//img.mapado.net/2014/1/1/my-image';
         $url = $this->manager->buildUrl($baseUrl, 200);
-        $this->assertSame($baseUrl . '_thumbs/200', $url);
+        $this->assertSame($baseUrl . '_thumbs/200-0', $url);
+
+        $baseUrl = '//img.mapado.net/2014/1/1/my-image';
+        $url = $this->manager->buildUrl($baseUrl, 0, 200);
+        $this->assertSame($baseUrl . '_thumbs/0-200', $url);
 
         $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
         $url = $this->manager->buildUrl($baseUrl, 200);
-        $this->assertSame($baseUrl . '_thumbs/200.png', $url);
+        $this->assertSame($baseUrl . '_thumbs/200-0.png', $url);
 
         $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
         $url = $this->manager->buildUrl($baseUrl, 200, 150);
@@ -86,7 +90,7 @@ class BuilderTest extends TestCase
     {
         $baseUrl = '2014/1/1/my-image.png';
         $url = $this->manager->buildUrl($baseUrl);
-        $this->assertSame('//img1.mapado.net/' . $baseUrl, $url);
+        $this->assertSame('//img.mapado.net/' . $baseUrl, $url);
 
         $baseUrl = '2014/1/2/my-image.png';
         $url = $this->manager->buildUrl($baseUrl);
@@ -100,7 +104,7 @@ class BuilderTest extends TestCase
             ->withHttpPrefix()
             ->buildUrl($baseUrl);
 
-        $this->assertSame('http://img1.mapado.net/' . $baseUrl, $url);
+        $this->assertSame('http://img.mapado.net/' . $baseUrl, $url);
     }
 
     public function testBuildHttpsUrl()
@@ -110,7 +114,7 @@ class BuilderTest extends TestCase
             ->withHttpsPrefix()
             ->buildUrl($baseUrl);
 
-        $this->assertSame('https://img1.mapado.net/' . $baseUrl, $url);
+        $this->assertSame('https://img.mapado.net/' . $baseUrl, $url);
     }
 
     public function testBuildHttpDoesNotInterferWithInstance()
@@ -118,6 +122,6 @@ class BuilderTest extends TestCase
         $baseUrl = '2014/1/1/my-image.png';
         $this->manager->withHttpPrefix();
 
-        $this->assertSame('//img1.mapado.net/' . $baseUrl, $this->manager->buildUrl($baseUrl));
+        $this->assertSame('//img.mapado.net/' . $baseUrl, $this->manager->buildUrl($baseUrl));
     }
 }

--- a/Tests/Units/BuilderTest.php
+++ b/Tests/Units/BuilderTest.php
@@ -124,4 +124,15 @@ class BuilderTest extends TestCase
 
         $this->assertSame('//img.mapado.net/' . $baseUrl, $this->manager->buildUrl($baseUrl));
     }
+
+    public function testAllowwebp(): void
+    {
+        $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
+        $url = $this->manager->buildUrl($baseUrl, null, null);
+        $this->assertSame($baseUrl, $url);
+
+        $baseUrl = '//img.mapado.net/2014/1/1/my-image.png';
+        $url = $this->manager->buildUrl($baseUrl, null, null, ['allowwebp' => 1]);
+        $this->assertSame($baseUrl . '_thumbs/0-0.png', $url);
+    }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -33,14 +33,14 @@ class Builder
      * generate an image url from its slug
      *
      * @param string $imageSlug the image slug (ie. `/2018/01/foo.jpg`)
-     * @param int $width the output width
-     * @param int $height the output height
+     * @param ?int $width the output width
+     * @param ?int $height the output height
      * @param array<string, string|int> $options accept cropWidth, cropHeight or url options parameters (like `rcr`, etc.)
      */
     public function buildUrl(
         string $imageSlug,
-        int $width = 0,
-        int $height = 0,
+        ?int $width = null,
+        ?int $height = null,
         array $options = []
     ): string {
         $image = trim($imageSlug);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -53,7 +53,7 @@ class Builder
             $image = $host . $image;
         }
 
-        if (null !== $image && (null !== $width || null !== $height)) {
+        if (null !== $image && (null !== $width || null !== $height || !empty($options))) {
             $extension = pathinfo($image, PATHINFO_EXTENSION);
             $extLen = strlen($extension);
             if ($extLen > 4) {
@@ -75,9 +75,13 @@ class Builder
                 $optionValues = [];
                 ksort($options);
                 foreach ($options as $key => $value) {
-                    $optionValues[] = $key . '=' . $value;
+                    if ($key !== 'allowwebp') {
+                        $optionValues[] = $key . '=' . $value;
+                    }
                 }
-                $image .= '.' . implode(';', $optionValues);
+                if (!empty($optionValues)) {
+                    $image .= '.' . implode(';', $optionValues);
+                }
             }
 
             if ($extension) {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -49,21 +49,18 @@ class Builder
         }
 
         if (null !== $image && !preg_match('#^//img([1-3])?.mapado.net/#', $image)) {
-            $host = $this->getHost($image);
+            $host = '//img.mapado.net/';
             $image = $host . $image;
         }
 
-        if (null !== $image && $width > 0) {
+        if (null !== $image && (null !== $width || null !== $height)) {
             $extension = pathinfo($image, PATHINFO_EXTENSION);
             $extLen = strlen($extension);
             if ($extLen > 4) {
                 $extension = null;
             }
 
-            $image .= '_thumbs/' . $width;
-            if ($height > 0) {
-                $image .= '-' . $height;
-            }
+            $image .= '_thumbs/' . ($width ?? 0) . '-' . ($height ?? 0);
 
             if (!empty($options['cropWidth']) || !empty($options['cropHeight'])) {
                 $cropWidth = $options['cropWidth'] ?? 0;
@@ -89,20 +86,5 @@ class Builder
         }
 
         return $this->prefix . $image;
-    }
-
-    private function getHost(string $image): string
-    {
-        $matches = [];
-        preg_match('#^[0-9]{4}/[0-9]{1,2}/([0-9]{1,2})#', $image, $matches);
-        if (!empty($matches)) {
-            $shard = (int) $matches[1] % 2;
-            $shard = $shard ?: ''; // remove "0"
-        } else {
-            $shard = '';
-        }
-        $host = '//img' . $shard . '.mapado.net/';
-
-        return $host;
     }
 }


### PR DESCRIPTION
### Nouveau comportement

Les nouveaux serveurs d'image sont http2.

[Grace au multiplexage apporté par http2](https://www.cloudflare.com/fr-fr/learning/performance/http2-vs-http1.1/), on n'a plus besoin de séparer les calls sur le serveur (entre img.mapado.net et img1.mapado.net)

Par ailleurs, on permet à présent un redimensionnement basé sur une hauteur (et pas seulement une largeur), ce qui est particulièrement pratique pour un logo affiché sur une ligne dont on connait la hauteur, mais dont la largeur peut varier.

### Tache Clickup

🧑‍🔧 