### PR TITLE
Add failover server in Image Builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -36,12 +36,14 @@ class Builder
      * @param ?int $width the output width
      * @param ?int $height the output height
      * @param array<string, string|int> $options accept cropWidth, cropHeight or url options parameters (like `rcr`, etc.)
+     * @param ?bool $useFailover if true, will use failover server
      */
     public function buildUrl(
         string $imageSlug,
         ?int $width = null,
         ?int $height = null,
-        array $options = []
+        array $options = [],
+        ?bool $useFailover = false,
     ): string {
         $image = trim($imageSlug);
         if (0 === strpos($image, 'http://') || 0 === strpos($image, 'https://')) {
@@ -51,6 +53,10 @@ class Builder
         if (null !== $image && !preg_match('#^//img([1-3])?.mapado.net/#', $image)) {
             $host = '//img.mapado.net/';
             $image = $host . $image;
+        }
+
+        if (null !== $image && $useFailover && preg_match('#^//img([1-3])?.mapado.net/#', $image)) {
+            $image = preg_replace('#^//img([1-3])?\.mapado\.net/#', '//failover-img.mapado.net/', $image);
         }
 
         if (null !== $image && (null !== $width || null !== $height || !empty($options))) {

--- a/src/Twig/UrlBuilderExtension.php
+++ b/src/Twig/UrlBuilderExtension.php
@@ -39,6 +39,7 @@ class UrlBuilderExtension extends AbstractExtension
         int $height = 0,
         array $options = []
     ): string {
-        return $this->builder->buildUrl($image, $width, $height, $options);
+        // By default, for the twig extension, we use the failover server
+        return $this->builder->buildUrl($image, $width, $height, $options, true);
     }
 }


### PR DESCRIPTION
### Current behavior

We use `img.mapado.net` subdomain to load images.
This address is a "random" DNS pointing between several servers to distribute the load.

However, if one of the servers crashes (which happened recently), we randomly have images that don't work while a devops adjust the setting and... waiting the cache to be refreshed (there is a 2-hour cache on resolution on this subdomain !). This might be a breaking issue on high load, as when an image doesn't work, it may crash generation of PDFs.

### New behavior

I'm adding an option to use a new subdomain, `failover-img.mapado.net`, to use when you have a "critical" need for an image.

This time, this address is not a "random DNS" between the two servers, but an address "monitored" by a third party.
This subdomain will point by default to a single server (hosted at OVH, the closest to our main production servers).
When it detects that the main server is down, in this case it will switch the DNS pointing to another server (hosted at Scaleway, our recovery platform) with a short time DNS cache delay.

It is not meant to be used in basic "front" needs (img.mapado.net is still the main subdomain to be used), because it is expensive in machine resources (instead of distributing the load, it concentrate it on one server) and in DNS calls (because of the low DNS cache delay). We use it by default in the twig extension, as this is mainly (only?) used in our PDF generation process.

### Clickup Task

🧑‍🔧